### PR TITLE
BREAKING: Change how permissions are defined and enforced

### DIFF
--- a/lib/puppet/provider/gpfs_fileset/shell.rb
+++ b/lib/puppet/provider/gpfs_fileset/shell.rb
@@ -56,6 +56,7 @@ Puppet::Type.type(:gpfs_fileset).provide(:shell, parent: Puppet::Provider::Gpfs)
             group = s.gid
           end
           fileset[:owner] = "#{user}:#{group}"
+          fileset[:permissions] = s.mode.to_s(8).split('')[-4..-1].join
         end
         filesets << new(fileset)
       end
@@ -199,6 +200,13 @@ Puppet::Type.type(:gpfs_fileset).provide(:shell, parent: Puppet::Provider::Gpfs)
           chown(@property_flush[:owner], path)
         else
           Puppet.warning("Unable to set owner for #{resource.type} #{resource.name}, path #{path} does not exist")
+        end
+      end
+      if @property_flush[:permissions] && resource[:enforce_permissions].to_s == 'true'
+        if File.directory?(path)
+          chmod(@property_flush[:permissions], path)
+        else
+          Puppet.warning("Unable to set permissions for #{resource.type} #{resource.name}, path #{path} does not exist")
         end
       end
     end

--- a/lib/puppet/type/gpfs_fileset.rb
+++ b/lib/puppet/type/gpfs_fileset.rb
@@ -77,12 +77,29 @@ Puppet::Type.newtype(:gpfs_fileset) do
     end
   end
 
-  newparam(:permissions) do
+  newproperty(:permissions) do
     desc 'Permissions of fileset.'
 
     munge do |value|
-      value.to_i
+      value.to_s
     end
+
+    validate do |value|
+      if value.to_s !~ %r{([0-7]{4,4})}
+        raise ArgumentError, 'Permissions must be valid POSIX permissions string, not %s' % value
+      end
+    end
+
+    def insync?(is)
+      return true if @resource[:enforce_permissions].to_s == 'false'
+      super(is)
+    end
+  end
+
+  newparam(:enforce_permissions) do
+    desc 'Enforce POSIX permissions after creation'
+    newvalues(:true, :false)
+    defaultto(:false)
   end
 
   newparam(:inode_space) do

--- a/spec/unit/puppet/type/gpfs_fileset_spec.rb
+++ b/spec/unit/puppet/type/gpfs_fileset_spec.rb
@@ -81,9 +81,21 @@ describe Puppet::Type.type(:gpfs_fileset) do
 
   it 'accepts permissions' do
     fileset[:permissions] = '1770'
-    expect(fileset[:permissions]).to eq(1770)
+    expect(fileset[:permissions]).to eq('1770')
     fileset[:permissions] = '0770'
-    expect(fileset[:permissions]).to eq(770)
+    expect(fileset[:permissions]).to eq('0770')
+  end
+
+  it 'does not accept invalid permissions of 3 digits' do
+    expect {
+      fileset[:permissions] = '700'
+    }.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'does not accept invalid permissions' do
+    expect {
+      fileset[:permissions] = 'foo'
+    }.to raise_error(Puppet::ResourceError)
   end
 
   it 'has inode_space default to new' do


### PR DESCRIPTION
Permissions must now be 4 octal digits, ie `1770` or `0770`.  Support enforcing permissions after creation via `enforce_permissions` parameter to `gpfs_fileset`.